### PR TITLE
Fix float type to str type

### DIFF
--- a/InstagramAPI/src/http/HttpInterface.py
+++ b/InstagramAPI/src/http/HttpInterface.py
@@ -201,7 +201,7 @@ class HttpInterface(object):
 
         endpoint = Constants.API_URL + 'upload/video/'
         boundary = self.parent.uuid
-        upload_id = round(float('%.2f' % time.time()) * 1000)
+        upload_id = str(int(round(float('%.2f' % time.time()) * 1000)))
         bodies = [
             OrderedDict([
                 ('type', 'form-data'),


### PR DESCRIPTION
If upload_id type is float, uploadVideo will have TypeError.
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-d610562e7b00> in <module>()
----> 1 insta.uploadVideo('/home/tu/test.mp4', 'Hello guys')

/home/tu/.virtualenvs/money_tool/local/lib/python2.7/site-packages/InstagramAPI/src/Instagram.pyc in uploadVideo(self, video, caption)
    330         :return: Upload data
    331         """
--> 332         return self.http.uploadVideo(video, caption)
    333 
    334     def direct_share(self, media_id, recipients, text=None):

/home/tu/.virtualenvs/money_tool/local/lib/python2.7/site-packages/InstagramAPI/src/http/HttpInterface.pyc in uploadVideo(self, video, caption)
    226         ]
    227 
--> 228         data = self.buildBody(bodies, boundary)
    229         headers = [
    230             'Connection: close',

/home/tu/.virtualenvs/money_tool/local/lib/python2.7/site-packages/InstagramAPI/src/http/HttpInterface.pyc in buildBody(self, bodies, boundary)
    582                 for header in b['headers']:
    583                     body += ("\r\n" + header)
--> 584             body += ("\r\n\r\n" + b['data'] + "\r\n")
    585         body += ('--' + boundary + '--')
    586 

TypeError: cannot concatenate 'str' and 'float' objects
```